### PR TITLE
Set room in author when receive a message

### DIFF
--- a/src/vsonline-adapter.coffee
+++ b/src/vsonline-adapter.coffee
@@ -92,15 +92,15 @@ class vsOnline extends Adapter
             @registerRoomUsersIfNecessary event.postedRoomId, event.content, () =>
               id =  event.postedBy.id
               author =
-              speaker_id: id
-              event_id: event.id
-              id : id
-              displayName : event.postedBy.displayName
+                speaker_id: id
+                event_id: event.id
+                id : id
+                displayName : event.postedBy.displayName
+                room: event.postedRoomId
             
               @registerRoomUser id, event.postedBy.displayName
                         
               message = new TextMessage(author, event.content)
-              message.room = event.postedRoomId          
               @receive message
   
   # Register the room users, if the pattern is a potential command that will 


### PR DESCRIPTION
Minor fix to set the room in author when receiving a message, since TextMessage constructor propagated this room value to its message.room.
