### PR TITLE
auto rejoin rooms. upgrade minimum vso client

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "express": "3.3.4",
-    "vso-client": ">=0.1.2"
+    "vso-client": ">=0.1.4"
   },
   "keywords": [
     "hubot",

--- a/readme.md
+++ b/readme.md
@@ -25,9 +25,8 @@ The VSOnline adapter requires the following environment variables.
 
 	HUBOT_VSONLINE_USERNAME - The account name that you would like to run hubot under
 	HUBOT_VSONLINE_PASSWORD - The account password
-	HUBOT_TFID - The TFID of the hubot account.  You can get this by logging into your Team Project as the hubot account and navigating to https://myacount.visualstudio.com/DefaultCollection/_api/_common/GetUserProfile?__v=4
 	HUBOT_VSONLINE_ACCOUNT- The name of your Visual Studio Online account e.g. if the url that you connect to is "https://yourname.visualstudio.com/" then just use 'your name'
-	HUBOT_VSONLINE_ROOMS - A comma seperated list of rooms that you would like hubot to join
+	HUBOT_VSONLINE_ROOMS - A comma separated list of rooms that you would like hubot to join
 	PORT - Port number for hubot to listen on when receiving messages from the Team Room.  This will default to 8080
    
 ## License

--- a/src/vsonline-adapter.coffee
+++ b/src/vsonline-adapter.coffee
@@ -36,6 +36,11 @@ class vsOnline extends Adapter
   # how much time we allow to elase before getting the room users and register
   # them on the brain
   MAXSECONDSBETWEENREGISTRATIONS = 10 * 60
+  
+  # Periodic interval to which we automatically rejoin rooms,so hubot doesn't appear idle
+  # rejoin every 23 hours
+  REJOININTERVAL = 1000 * 60 * 60 * 23.5
+  
   # if any of these expressions are found in a command, we fetch the room users
   # and place them on the brain before passing the command to hubot.
   # We do this to place users into the brain (to support authorization) since
@@ -79,8 +84,6 @@ class vsOnline extends Adapter
       process.exit(1)
 
     @robot.logger.info "Initialize"
-            
-    client = Client.createClient accountName, collection, username, password
     
     auth = require('express').basicAuth adapterAuthUser, adapterAuthPassword
 
@@ -94,11 +97,30 @@ class vsOnline extends Adapter
         res.send(204)
       
     @emit "connected"
-    
+    @joinRooms()
+    @setPeriodicRoomJoin()
+
+
+  setPeriodicRoomJoin: =>
+    # if there are rooms to join, set interval
+    if rooms.length >= 1 and rooms[0] != ""
+      @robot.logger.info "setting rejoin timer"
+      setInterval @rejoinRooms, REJOININTERVAL
+    else
+      @robot.logger.info "setting rejoin timer. No rooms to rejoin"
+      
+  rejoinRooms: =>
+    @robot.logger.info "rejoining rooms"
+    @joinRooms()
+        
+  joinRooms: =>
     # no rooms to join.
     if rooms.length == 1 and rooms[0] == ""
       return
     
+    @robot.logger.debug "joining rooms"
+    
+    client = Client.createClient accountName, collection, username, password
     client.getRooms (err, returnRooms) =>
       if err
         @robot.logger.error err


### PR DESCRIPTION
Auto rejoin rooms after 23 and a half hours
Updated readme to remove the need to specify TF ID
Change minimum VSO client version because we need connectionDataMethod
