### PR TITLE
Azure Service Bus Queue receive mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "url": "http://github.com/scrumdod/hubot-VSOnline"
   },
   "dependencies": {
+    "azure": "^0.9.10",
     "express": "3.3.4",
     "vso-client": ">=0.1.2"
   },

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ The VSOnline adapter supports two modes to receive team room messages:
 To use this mode the adapter requires the following environment variables
 
     HUBOT_VSONLINE_ADAPTER_RECV_MODE - must be set to  servicebus.
-    HUBOT_VSONLINE_ADAPTER_SERVICE_BUS_SAS_CONNSTR - The Service Bus SAS connection string
+    HUBOT_VSONLINE_ADAPTER_SERVICE_BUS_CONNECTION - The Service Bus SAS connection string
     HUBOT_VSONLINE_ADAPTER_SERVICE_BUS_QUEUE - The Service Bus queue name
 
 

--- a/readme.md
+++ b/readme.md
@@ -42,9 +42,9 @@ The VSOnline adapter supports two modes to receive team room messages:
 
 To use this mode the adapter requires the following environment variables
 
-+ `HUBOT_VSONLINE_ADAPTER_RECV_MODE` - must be set to  **`servicebus`**.
-+ HUBOT_VSONLINE_ADAPTER_SERVICE_BUS_SAS_CONNSTR - The Service Bus SAS connection string
-+ HUBOT_VSONLINE_ADAPTER_SERVICE_BUS_QUEUE - The Service Bus queue name
+    HUBOT_VSONLINE_ADAPTER_RECV_MODE - must be set to  servicebus.
+    HUBOT_VSONLINE_ADAPTER_SERVICE_BUS_SAS_CONNSTR - The Service Bus SAS connection string
+    HUBOT_VSONLINE_ADAPTER_SERVICE_BUS_QUEUE - The Service Bus queue name
 
 
 

--- a/readme.md
+++ b/readme.md
@@ -25,11 +25,29 @@ The VSOnline adapter requires the following environment variables.
 
 	HUBOT_VSONLINE_USERNAME - The account name that you would like to run hubot under
 	HUBOT_VSONLINE_PASSWORD - The account password
-	HUBOT_TFID - The TFID of the hubot account.  You can get this by logging into your Team Project as the hubot account and navigating to https://myacount.visualstudio.com/DefaultCollection/_api/_common/GetUserProfile?__v=4
 	HUBOT_VSONLINE_ACCOUNT- The name of your Visual Studio Online account e.g. if the url that you connect to is "https://yourname.visualstudio.com/" then just use 'your name'
 	HUBOT_VSONLINE_ROOMS - A comma seperated list of rooms that you would like hubot to join
 	PORT - Port number for hubot to listen on when receiving messages from the Team Room.  This will default to 8080
+    HUBOT_VSONLINE_ADAPTER_BASIC_AUTH_USERNAME - The adapter's endpoint basic authentication username
+    HUBOT_VSONLINE_ADAPTER_BASIC_AUTH_PASSWORD - The adapter's endpoint basic authentication password
    
+
+The VSOnline adapter supports two modes to receive team room messages:
+
+* HTTP - This is the default mode where the adapter listens for team room messages in a HTTP endpoint.
+* Service Bus Queue - In this mode the adapter reads messages from an Azure Service Bus Queue. 
+
+
+### Azure Service Bus Queue 
+
+To use this mode the adapter requires the following environment variables
+
++ `HUBOT_VSONLINE_ADAPTER_RECV_MODE` - must be set to  **`servicebus`**.
++ HUBOT_VSONLINE_ADAPTER_SERVICE_BUS_SAS_CONNSTR - The Service Bus SAS connection string
++ HUBOT_VSONLINE_ADAPTER_SERVICE_BUS_QUEUE - The Service Bus queue name
+
+
+
 ## License
 
 MIT

--- a/src/vsonline-adapter.coffee
+++ b/src/vsonline-adapter.coffee
@@ -21,7 +21,7 @@ class vsOnline extends Adapter
   adapterAuthPassword   = process.env.HUBOT_VSONLINE_ADAPTER_BASIC_AUTH_PASSWORD
   
   ## Variables to define adapter service bus queue to receive messages
-  sbConnStr = process.env.HUBOT_VSONLINE_ADAPTER_SERVICE_BUS_SAS_CONNSTR
+  sbConnStr = process.env.HUBOT_VSONLINE_ADAPTER_SERVICE_BUS_CONNECTION
   sbQueue = process.env.HUBOT_VSONLINE_ADAPTER_SERVICE_BUS_QUEUE
   sbRecvMsgTimeoutInS = process.env.HUBOT_VSONLINE_ADAPTER_SERVICE_BUS_RECV_MSG_TIMEOUT or 55
   sbRecvLoopTimeoutInMs = (process.env.HUBOT_VSONLINE_ADAPTER_SERVICE_BUS_RECV_LOOP_TIMEOUT or 0) * 1000
@@ -102,7 +102,7 @@ class vsOnline extends Adapter
       process.exit(1)
 
     if adapterRecvMode is 'servicebus' and not (sbConnStr and sbQueue)
-      @robot.logger.error "Not enough parameters for service bus. I need HUBOT_VSONLINE_ADAPTER_SERVICE_BUS_SAS_CONNSTR and HUBOT_VSONLINE_ADAPTER_SERVICE_BUS_QUEUE variables. Terminating"
+      @robot.logger.error "Not enough parameters for service bus. I need HUBOT_VSONLINE_ADAPTER_SERVICE_BUS_CONNECTION and HUBOT_VSONLINE_ADAPTER_SERVICE_BUS_QUEUE variables. Terminating"
       process.exit(1)
 
 

--- a/src/vsonline-adapter.coffee
+++ b/src/vsonline-adapter.coffee
@@ -2,13 +2,29 @@ Client                                               = require 'vso-client'
 {Robot, Adapter, normal,TextMessage,EnterMessage,LeaveMessage,TopicMessage} = require 'hubot'
 https = require('https')
 fs = require('fs')
+azure = require 'azure'
+util = require 'util'
 
+
+VSONLINE_ADAPTER_RECV_VALID_MODES = [
+  'http',
+  'servicebus'
+]
 
 class vsOnline extends Adapter
 
-  ## Variables to define adapter auth to receive messages
+  ## Defines the adapter mode
+  adapterRecvMode = process.env.HUBOT_VSONLINE_ADAPTER_RECV_MODE or 'http'
+
+  ## Variables to define adapter basic auth to receive messages
   adapterAuthUser       = process.env.HUBOT_VSONLINE_ADAPTER_BASIC_AUTH_USERNAME
   adapterAuthPassword   = process.env.HUBOT_VSONLINE_ADAPTER_BASIC_AUTH_PASSWORD
+  
+  ## Variables to define adapter service bus queue to receive messages
+  sbConnStr = process.env.HUBOT_VSONLINE_ADAPTER_SERVICE_BUS_SAS_CONNSTR
+  sbQueue = process.env.HUBOT_VSONLINE_ADAPTER_SERVICE_BUS_QUEUE
+  sbRecvMsgTimeoutInS = process.env.HUBOT_VSONLINE_ADAPTER_SERVICE_BUS_RECV_MSG_TIMEOUT or 55
+  sbRecvLoopTimeoutInS = process.env.HUBOT_VSONLINE_ADAPTER_SERVICE_BUS_RECV_LOOP_TIMEOUT or 0
 
   ## Variables to support SSL (optional)
   SSLEnabled        = process.env.HUBOT_VSONLINE_SSL_ENABLE || false
@@ -74,30 +90,37 @@ class vsOnline extends Adapter
 
   run: ->
   
-    unless adapterAuthUser and adapterAuthPassword
-      @robot.logger.error "not enough parameters for auth. I need HUBOT_VSONLINE_ADAPTER_BASIC_AUTH_USERNAME and HUBOT_VSONLINE_ADAPTER_BASIC_AUTH_PASSWORD variables. Terminating"
+    unless adapterRecvMode in VSONLINE_ADAPTER_RECV_VALID_MODES
+      @robot.logger.error "Invalid #{adapterRecvMode} receive mode set in variable \
+        HUBOT_VSONLINE_ADAPTER_RECV_MODE. Valid modes are #{util.inspect(VSONLINE_ADAPTER_RECV_VALID_MODES)}.\
+        Terminating."
       process.exit(1)
+      
+    if adapterRecvMode is 'http' and not (adapterAuthUser and adapterAuthPassword)
+      @robot.logger.error "Not enough parameters for http basic auth. I need HUBOT_VSONLINE_ADAPTER_BASIC_AUTH_USERNAME and HUBOT_VSONLINE_ADAPTER_BASIC_AUTH_PASSWORD variables. Terminating"
+      process.exit(1)
+
+    if adapterRecvMode is 'servicebus' and not (sbConnStr and sbQueue)
+      @robot.logger.error "Not enough parameters for service bus. I need HUBOT_VSONLINE_ADAPTER_SERVICE_BUS_SAS_CONNSTR and HUBOT_VSONLINE_ADAPTER_SERVICE_BUS_QUEUE variables. Terminating"
+      process.exit(1)
+
 
     @robot.logger.info "Initialize"
             
     client = Client.createClient accountName, collection, username, password
-    
-    auth = require('express').basicAuth adapterAuthUser, adapterAuthPassword
-
-    if(SSLEnabled)
-      @configureSSL auth
-
-    @robot.router.post hubotUrl, auth, (req, res) =>
-      @robot.logger.debug "New message posted to adapter"
-      if(req.body.eventType == "message.posted")
-        @processEvent req.body.resource
-        res.send(204)
+      
+    if adapterRecvMode is 'http'
+      @configureHttpReceiver()
+    else if adapterRecvMode is 'servicebus'
+      @configureServiceBusReceiver()
+    else
+      @robot.logger.error "Receive mode #{adaperRecvMode} not suported"
+      process.exit(1)
       
     @emit "connected"
     
     # no rooms to join.
-    if rooms.length == 1 and rooms[0] == ""
-      return
+    return if rooms.length == 1 and rooms[0] == ""
     
     client.getRooms (err, returnRooms) =>
       if err
@@ -113,6 +136,19 @@ class vsOnline extends Adapter
               else
                 @robot.logger.warning "Room not found " + room
                   
+
+  configureHttpReceiver: => 
+    auth = require('express').basicAuth adapterAuthUser, adapterAuthPassword
+
+    if(SSLEnabled)
+      @configureSSL auth
+
+    @robot.router.post hubotUrl, auth, (req, res) =>
+      @robot.logger.debug "New message posted to adapter"
+      if(req.body.eventType == "message.posted")
+        @processEvent req.body.resource
+        res.send(204)
+  
 
   # configure SSL to listen on the configured port. We need at least a private key
   # and a certificate.        
@@ -133,6 +169,31 @@ class vsOnline extends Adapter
       sslOptions.ca = ca: fs.readFileSync(SSLCACertPath)
    
     https.createServer(sslOptions, @robot.router).listen(SSLPort)
+
+  configureServiceBusReceiver: =>
+  
+    serviceBusSvc = azure.createServiceBusService(sbConnStr)
+
+    recv = ()=>
+      @robot.logger.debug "Starting a new cycle to read messages from SB Q"
+      serviceBusSvc.receiveQueueMessage sbQueue,
+        timeoutIntervalInS: sbRecvMsgTimeoutInS,
+        (err, receivedMessage) =>
+          if !err
+            @robot.logger.debug "New message received from Q"
+            #schedule a new loop immediately
+            setTimeout recv, 0  
+            event = JSON.parse receivedMessage.body
+            @processEvent event.resource if event.eventType is "message.posted"
+          else
+            @robot.logger.warning "Couldn't receive any message from Q: \
+              #{util.inspect err}"
+            setTimeout recv, sbRecvLoopTimeoutInS
+          
+      
+    #start receiving loop
+    recv()
+      
 
   registerRoomUsers: (client, roomId, callback) =>
     @robot.logger.debug "Registering users for room " + roomId

--- a/src/vsonline-adapter.coffee
+++ b/src/vsonline-adapter.coffee
@@ -24,7 +24,7 @@ class vsOnline extends Adapter
   sbConnStr = process.env.HUBOT_VSONLINE_ADAPTER_SERVICE_BUS_SAS_CONNSTR
   sbQueue = process.env.HUBOT_VSONLINE_ADAPTER_SERVICE_BUS_QUEUE
   sbRecvMsgTimeoutInS = process.env.HUBOT_VSONLINE_ADAPTER_SERVICE_BUS_RECV_MSG_TIMEOUT or 55
-  sbRecvLoopTimeoutInS = process.env.HUBOT_VSONLINE_ADAPTER_SERVICE_BUS_RECV_LOOP_TIMEOUT or 0
+  sbRecvLoopTimeoutInMs = (process.env.HUBOT_VSONLINE_ADAPTER_SERVICE_BUS_RECV_LOOP_TIMEOUT or 0) * 1000
 
   ## Variables to support SSL (optional)
   SSLEnabled        = process.env.HUBOT_VSONLINE_SSL_ENABLE || false
@@ -188,7 +188,7 @@ class vsOnline extends Adapter
           else
             @robot.logger.warning "Couldn't receive any message from Q: \
               #{util.inspect err}"
-            setTimeout recv, sbRecvLoopTimeoutInS
+            setTimeout recv, sbRecvLoopTimeoutInMs
           
       
     #start receiving loop


### PR DESCRIPTION
Support to use an Azure Service Bus Queue to receive team room messages instead of HTTP.
